### PR TITLE
Change how recipients are handled.

### DIFF
--- a/django_mailjet/backends.py
+++ b/django_mailjet/backends.py
@@ -114,8 +114,8 @@ class MailjetBackend(BaseEmailBackend):
         msg_dict['FromEmail'] = from_email
         msg_dict['FromName'] = from_name
 
-        # Place email recipients into To field, unless Cc or Bcc are used, in
-        # that case, place recipients into Receipients. According to Mailjet:
+        # Place email recipients into Recipients field, unless Cc or Bcc are
+        # used, in that case, place recipients into To. According to Mailjet:
         #
         # Important: Recipients and To have a different behaviors. The
         # recipients listed in To will recieve a common message showing every

--- a/django_mailjet/backends.py
+++ b/django_mailjet/backends.py
@@ -42,8 +42,13 @@ class MailjetBackend(BaseEmailBackend):
         recipient_vars = getattr(message, 'recipient_vars', {})
 
         for addr in recipients:
+            rcpt = {}
             to_name, to_email = parseaddr(sanitize_address(addr, message.encoding))
-            rcpt = {'Email': to_email, 'Name': to_name}
+
+            if to_name:
+                rcpt['Name'] = to_name
+            if to_email:
+                rcpt['Email'] = to_email
 
             if recipient_vars.get(addr):
                 rcpt['Vars'] = recipient_vars.get(addr)
@@ -71,7 +76,7 @@ class MailjetBackend(BaseEmailBackend):
         return True
 
     def build_send_payload(self, message):
-        msg_dict = self._build_standart_message_dict(message)
+        msg_dict = self._build_standard_message_dict(message)
         self._add_mailjet_options(message, msg_dict)
 
         if getattr(message, 'alternatives', None):
@@ -94,7 +99,7 @@ class MailjetBackend(BaseEmailBackend):
             raise MailjetAPIError("Invalid JSON in Mailjet API response",
                 email_message=message, payload=payload, response=response)
 
-    def _build_standart_message_dict(self, message):
+    def _build_standard_message_dict(self, message):
         msg_dict = dict()
 
         if len(message.subject):
@@ -109,13 +114,25 @@ class MailjetBackend(BaseEmailBackend):
         msg_dict['FromEmail'] = from_email
         msg_dict['FromName'] = from_name
 
-        msg_dict['To'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.to])
+        # Place email recipients into To field, unless Cc or Bcc are used, in
+        # that case, place recipients into Receipients. According to Mailjet:
+        #
+        # Important: Recipients and To have a different behaviors. The
+        # recipients listed in To will recieve a common message showing every
+        # other recipients and carbon copies recipients. The recipients listed
+        # in Recipients will each recieve an seperate message without showing
+        # all the other recipients.
+        rcpt_key = 'Recipients'
 
         if message.cc:
             msg_dict['Cc'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.cc])
+            rcpt_key = 'To'
 
         if message.bcc:
             msg_dict['Bcc'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.bcc])
+            rcpt_key = 'To'
+
+        msg_dict[rcpt_key] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.to])
 
         if message.reply_to:
             reply_to = [sanitize_address(addr, message.encoding) for addr in message.reply_to]

--- a/django_mailjet/backends.py
+++ b/django_mailjet/backends.py
@@ -122,17 +122,20 @@ class MailjetBackend(BaseEmailBackend):
         # other recipients and carbon copies recipients. The recipients listed
         # in Recipients will each recieve an seperate message without showing
         # all the other recipients.
-        rcpt_key = 'Recipients'
+        use_recipients = True
 
         if message.cc:
             msg_dict['Cc'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.cc])
-            rcpt_key = 'To'
+            use_recipients = False
 
         if message.bcc:
             msg_dict['Bcc'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.bcc])
-            rcpt_key = 'To'
+            use_recipients = True
 
-        msg_dict[rcpt_key] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.to])
+        if use_recipients:
+            msg_dict['Recipients'] = self._parse_recipients(message, message.to)
+        else:
+            msg_dict['To'] = ', '.join([sanitize_address(addr, message.encoding) for addr in message.to])
 
         if message.reply_to:
             reply_to = [sanitize_address(addr, message.encoding) for addr in message.reply_to]


### PR DESCRIPTION
Don't fill in Name field if it is not provided. Use `Recipients` unless `Cc` or `Bcc` fields are used.